### PR TITLE
Timeout das requisições SOAP corrigido

### DIFF
--- a/app/code/community/LithiumSoftware/Akhilleus/Model/Carrier/Akhilleus.php
+++ b/app/code/community/LithiumSoftware/Akhilleus/Model/Carrier/Akhilleus.php
@@ -117,7 +117,9 @@ class LithiumSoftware_Akhilleus_Model_Carrier_Akhilleus
     protected function _getWebServicesQuoteReturn(Mage_Shipping_Model_Rate_Request $request)
     {
         $url    = $this->getConfigData('url_ws');
-        $client = new SoapClient($url, array("soap_version" => SOAP_1_1,"trace" => 1, "cache_wsdl" => WSDL_CACHE_NONE));
+        $config = LithiumSoftware_Akhilleus_Helper_Data::SOAP_CLIENT_SETTINGS;
+        ini_set('default_socket_timeout', $config['connection_timeout']);
+        $client = new SoapClient($url, $config);
 
         try {
             if ($this->getConfigFlag('use_default'))
@@ -508,7 +510,10 @@ class LithiumSoftware_Akhilleus_Model_Carrier_Akhilleus
         }
 
         $url    = $this->getConfigData('url_ws');
-        $client = new SoapClient($url, array("soap_version" => SOAP_1_1,"trace" => 1));
+        $config = LithiumSoftware_Akhilleus_Helper_Data::SOAP_CLIENT_SETTINGS;
+        ini_set('default_socket_timeout', $config['connection_timeout']);
+        $client = new SoapClient($url, $config);
+
         //$orderId = Mage::getModel("sales/order")->getCollection()->getLastItem()->getIncrementId();
         $order = Mage::getModel('sales/order')->load($orderId);
 

--- a/app/code/community/LithiumSoftware/Akhilleus/Model/Observer.php
+++ b/app/code/community/LithiumSoftware/Akhilleus/Model/Observer.php
@@ -54,7 +54,9 @@ class LithiumSoftware_Akhilleus_Model_Observer  extends Mage_Core_Model_Abstract
         $url = Mage::getStoreConfig('carriers/akhilleus/url_ws');
 
         try {
-            $client = new SoapClient($url, array("soap_version" => SOAP_1_1,"trace" => 1));
+            $config = LithiumSoftware_Akhilleus_Helper_Data::SOAP_CLIENT_SETTINGS;
+            ini_set('default_socket_timeout', $config['connection_timeout']);
+            $client = new SoapClient($url, $config);
 
             $login = Mage::getStoreConfig('carriers/akhilleus/login');
             $password = Mage::getStoreConfig('carriers/akhilleus/password');


### PR DESCRIPTION
O timeout de 7 segundos não estava sendo respeitado, o que foi corrigido por definir o `default_socket_timeout` antes da requisição.